### PR TITLE
Additional functionality for Certificate sample app

### DIFF
--- a/Certificates/README.md
+++ b/Certificates/README.md
@@ -3,7 +3,8 @@
 This sample app shows how an app can support user certificate upload at runtime.
 
 In this app a user can upload a certificate to trust, and can test the certificate has been added successfully by
-making a HTTP GET request to a provided URL.
+making a HTTP GET request to an external URL. This URL must be one that requires a client certificate for authentication
+and can not be any URL such as the QRadar console as this will not test the certificate.
 
 If a user wants to have the certificate trusted by QRadar as a whole, they can use the Certificate Management App
 which is accessed by a link such as the one in this sample app.

--- a/Certificates/README.md
+++ b/Certificates/README.md
@@ -5,6 +5,9 @@ This sample app shows how an app can support user certificate upload at runtime.
 In this app a user can upload a certificate to trust, and can test the certificate has been added successfully by
 making a HTTP GET request to a provided URL.
 
+If a user wants to have the certificate trusted by QRadar as a whole, they can use the Certificate Management App
+which is accessed by a link such as the one in this sample app.
+
 ## Importing certificates
 
 QRadar apps can add custom certificates by placing the certificate in the certificate directory inside the persistant

--- a/Certificates/app/templates/index.html
+++ b/Certificates/app/templates/index.html
@@ -32,11 +32,13 @@ limitations under the License.
   </form>
   <form id="http-form" method="GET">
     <h2 id="http-title">Make a HTTP GET request from app backend</h2>
+    <h3 id="upload-test">Test uploaded certificate</h3>
+    <h4>Enter a url that requires a client certificate for authentication</h4>
     <div>
       <label>Address to send a HTTP GET request to</label>
       <input id="http-input" type="url" name="address" placeholder="https://..." />
     </div>
-    <input id="http-submit" type="submit" value="Send request" />
+    <input id="http-submit" type="submit" value="Test" />
   </form>
   {% if url %}
   <div>
@@ -44,6 +46,13 @@ limitations under the License.
     <div>
       <label>Address:</label>
       <span id="result-url">{{ url }}</span>
+    </div>
+    <div>
+      {% if status_code==200 %}
+      <span id="success">Test Successful</span>
+      {% else %} 
+      <span id="unsuccessful">There was a problem with the test</span>
+      {% endif %} 
     </div>
     <div>
       <label>Status:</label>
@@ -55,6 +64,12 @@ limitations under the License.
     </div>
   </div>
   {% endif %}
+  {% if cert_app %}
+  <div>
+    <h2 id="cert-app">Certificate Management App</h2>
+    <a href={{ cert_app }} target="_blank">Upload Root Certificate with Certificate Management App</a>
+  </div>
+  {% endif %} 
 </body>
 
 </html>

--- a/Certificates/app/views.py
+++ b/Certificates/app/views.py
@@ -28,19 +28,23 @@ CERTS_DIRECTORY = '/opt/app-root/store/certs'
 @viewsbp.route('/')
 @viewsbp.route('/index')
 def index():
+    cert_app = get_certificate_management_app()
     url = request.args.get('address')
     if url is not None:
         try:
             response = requests.get(url)
-        except SSLError:
+        except SSLError as ssl_error:
             return render_template('index.html',
                                    url=url,
-                                   result='An SSL error occurred!')
+                                   result='An SSL error occurred!', 
+                                   status_code = str(ssl_error),
+                                   cert_app=cert_app)                 
         return render_template('index.html',
-                               url=url,
+                               url=url, 
                                status_code=response.status_code,
-                               result=response.text)
-    return render_template('index.html')
+                               result=response.text, cert_app=cert_app
+                               )
+    return render_template('index.html', cert_app=cert_app)
 
 
 @viewsbp.route('/upload_cert', methods=['POST'])
@@ -58,6 +62,22 @@ def upload_cert():
     refresh_certs()
     return redirect('/', code=303)
 
+def get_certificate_management_app():
+    params = {'filter': 'manifest(name)="QRadar Certificate Management" and application_state(status)="RUNNING"',
+              'fields': 'application_state'}
+    response = qpylib.REST(rest_action='GET',
+                            request_url='/api/gui_app_framework/applications',
+                            params=params)
+    if not response.status_code == 200:
+        qpylib.log('Failed to get Certificate Management App')
+    jsonResult = response.json()
+    address=""
+    if len(jsonResult) > 0:
+        for app_id in jsonResult:
+            cert_management_id = app_id['application_state']['application_id']
+        console_ip = qpylib.get_console_address()
+        address = "https://{0}/console/plugins/{1}/app_proxy/#/browse/uploadRoot".format(console_ip, cert_management_id)
+    return address
 
 def refresh_certs():
     os.system('sudo /opt/app-root/bin/update_ca_bundle.sh')


### PR DESCRIPTION
These new updates check to see if the Certificate Management App is installed. If it is installed a link to the root CA upload screen will be provided and if not the link will not be there. Rewording and extra information returned for testing if uploaded certificates are working with a url that requires a client certificate for authentication.